### PR TITLE
Deprecate extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][unreleased]
 
+## [1.1.0] - 2020-04-04
+
+### Deprecated
+
+**This extension has been deprecated**.  All of its functionality now exists in league/commonmark 1.3+ under the `League\CommonMark\Extension\Strikethrough` namespace.
+
 ## [1.0.0] - 2019-06-29
 
 No code changes have been introduced since 1.0.0-beta2.
@@ -54,7 +60,8 @@ These older releases come from the original `uafrica/commonmark-ext` library.
 
  - Updated to `league/commonmark` v0.17
 
-[unreleased]: https://github.com/thephpleague/commonmark-ext-strikethrough/compare/v1.0.0...HEAD
+[unreleased]: https://github.com/thephpleague/commonmark-ext-strikethrough/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/thephpleague/commonmark-ext-strikethrough/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/thephpleague/commonmark-ext-strikethrough/compare/v1.0.0-beta2...v1.0.0
 [1.0.0-beta2]: https://github.com/thephpleague/commonmark-ext-strikethrough/compare/v1.0.0-beta1...v1.0.0-beta2
 [1.0.0-beta1]: https://github.com/thephpleague/commonmark-ext-strikethrough/compare/v0.4.0...v1.0.0-beta1

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.1",
         "ext-mbstring": "*",
-        "league/commonmark": "^1.0"
+        "league/commonmark": "^1.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"
@@ -41,7 +41,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "1.2-dev"
         }
-    }
+    },
+    "abandoned": "league/commonmark"
 }

--- a/src/Strikethrough.php
+++ b/src/Strikethrough.php
@@ -13,13 +13,21 @@ namespace League\CommonMark\Ext\Strikethrough;
 
 use League\CommonMark\Inline\Element\AbstractInline;
 
-class Strikethrough extends AbstractInline
-{
+@trigger_error('league/commonmark-ext-strikethrough is deprecated; use League\CommonMark\Extension\Strikethrough\Strikethrough from league/commonmark 1.3+ instead', E_USER_DEPRECATED);
+class_alias('League\CommonMark\Extension\Strikethrough\Strikethrough', 'League\CommonMark\Ext\Strikethrough\Strikethrough');
+
+if (false) {
     /**
-     * @return bool
+     * @deprecated The league/commonmark-ext-strikethrough extension is now deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.
      */
-    public function isContainer(): bool
+    class Strikethrough extends AbstractInline
     {
-        return true;
+        /**
+         * @return bool
+         */
+        public function isContainer(): bool
+        {
+            return true;
+        }
     }
 }

--- a/src/StrikethroughDelimiterProcessor.php
+++ b/src/StrikethroughDelimiterProcessor.php
@@ -13,16 +13,28 @@ namespace League\CommonMark\Ext\Strikethrough;
 
 use League\CommonMark\Delimiter\DelimiterInterface;
 use League\CommonMark\Delimiter\Processor\DelimiterProcessorInterface;
+use League\CommonMark\Extension\Strikethrough\StrikethroughDelimiterProcessor as CoreProcessor;
 use League\CommonMark\Inline\Element\AbstractStringContainer;
 
+/**
+ * @deprecated The league/commonmark-ext-strikethrough extension is now deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.
+ */
 final class StrikethroughDelimiterProcessor implements DelimiterProcessorInterface
 {
+    private $coreProcessor;
+
+    public function __construct()
+    {
+        @trigger_error(sprintf('league/commonmark-ext-strikethrough is deprecated; use %s from league/commonmark 1.3+ instead', CoreProcessor::class), E_USER_DEPRECATED);
+        $this->coreProcessor = new CoreProcessor();
+    }
+
     /**
      * {@inheritdoc}
      */
     public function getOpeningCharacter(): string
     {
-        return '~';
+        return $this->coreProcessor->getOpeningCharacter();
     }
 
     /**
@@ -30,7 +42,7 @@ final class StrikethroughDelimiterProcessor implements DelimiterProcessorInterfa
      */
     public function getClosingCharacter(): string
     {
-        return '~';
+        return $this->coreProcessor->getClosingCharacter();
     }
 
     /**
@@ -38,7 +50,7 @@ final class StrikethroughDelimiterProcessor implements DelimiterProcessorInterfa
      */
     public function getMinLength(): int
     {
-        return 2;
+        return $this->coreProcessor->getMinLength();
     }
 
     /**
@@ -46,9 +58,7 @@ final class StrikethroughDelimiterProcessor implements DelimiterProcessorInterfa
      */
     public function getDelimiterUse(DelimiterInterface $opener, DelimiterInterface $closer): int
     {
-        $min = \min($opener->getLength(), $closer->getLength());
-
-        return $min >= 2 ? $min : 0;
+        return $this->coreProcessor->getDelimiterUse($opener, $closer);
     }
 
     /**
@@ -56,15 +66,6 @@ final class StrikethroughDelimiterProcessor implements DelimiterProcessorInterfa
      */
     public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse)
     {
-        $strikethrough = new Strikethrough();
-
-        $tmp = $opener->next();
-        while ($tmp !== null && $tmp !== $closer) {
-            $next = $tmp->next();
-            $strikethrough->appendChild($tmp);
-            $tmp = $next;
-        }
-
-        $opener->insertAfter($strikethrough);
+        return $this->coreProcessor->process($opener, $closer, $delimiterUse);
     }
 }

--- a/src/StrikethroughExtension.php
+++ b/src/StrikethroughExtension.php
@@ -13,12 +13,23 @@ namespace League\CommonMark\Ext\Strikethrough;
 
 use League\CommonMark\ConfigurableEnvironmentInterface;
 use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\Extension\Strikethrough\StrikethroughExtension as CoreExtension;
 
+/**
+ * @deprecated The league/commonmark-ext-strikethrough extension is now deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.
+ */
 final class StrikethroughExtension implements ExtensionInterface
 {
+    private $coreExtension;
+
+    public function __construct()
+    {
+        @trigger_error(sprintf('league/commonmark-ext-strikethrough is deprecated; use %s from league/commonmark 1.3+ instead', CoreExtension::class), E_USER_DEPRECATED);
+        $this->coreExtension = new CoreExtension();
+    }
+
     public function register(ConfigurableEnvironmentInterface $environment)
     {
-        $environment->addDelimiterProcessor(new StrikethroughDelimiterProcessor());
-        $environment->addInlineRenderer(Strikethrough::class, new StrikethroughRenderer());
+        $this->coreExtension->register($environment);
     }
 }

--- a/src/StrikethroughRenderer.php
+++ b/src/StrikethroughRenderer.php
@@ -12,21 +12,28 @@
 namespace League\CommonMark\Ext\Strikethrough;
 
 use League\CommonMark\ElementRendererInterface;
-use League\CommonMark\HtmlElement;
+use League\CommonMark\Extension\Strikethrough\StrikethroughRenderer as CoreRenderer;
 use League\CommonMark\Inline\Element\AbstractInline;
 use League\CommonMark\Inline\Renderer\InlineRendererInterface;
 
+/**
+ * @deprecated The league/commonmark-ext-strikethrough extension is now deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.
+ */
 final class StrikethroughRenderer implements InlineRendererInterface
 {
+    private $coreRenderer;
+
+    public function __construct()
+    {
+        @trigger_error(sprintf('league/commonmark-ext-strikethrough is deprecated; use %s from league/commonmark 1.3+ instead', CoreRenderer::class), E_USER_DEPRECATED);
+        $this->coreRenderer = new CoreRenderer();
+    }
+
     /**
      * {@inheritdoc}
      */
     public function render(AbstractInline $inline, ElementRendererInterface $htmlRenderer)
     {
-        if (!($inline instanceof Strikethrough)) {
-            throw new \InvalidArgumentException('Incompatible inline type: ' . get_class($inline));
-        }
-
-        return new HtmlElement('del', $inline->getData('attributes', []), $htmlRenderer->renderInlines($inline->children()));
+        return $this->coreRenderer->render($inline, $htmlRenderer);
     }
 }


### PR DESCRIPTION
The league/commonmark-ext-strikethrough extension is being deprecated. All functionality has been moved into league/commonmark 1.3+, so use that instead.